### PR TITLE
chore: bruker chainguard base images som anbefalt i Nav security playbook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/java/"
     schedule:
       interval: daily
+  - package-ecosystem: docker
+    directory: "/distroless/"
+    schedule:
+      interval: daily
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        version: [ '21', '24' ]
+        version: [ '21', '25' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
@@ -41,12 +41,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # For å hente chainguard image fra GAR
+      - name: NAIS login
+        uses: nais/login@e7cf2c159677dc7c7d599feff5f808f2bf59c7cf # ratchet:nais/login@v0
+        id: login
+        with:
+          team: teamforeldrepenger
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: java
           platforms: linux/amd64,linux/arm64
-          build-args: BASE_IMAGE=eclipse-temurin:${{matrix.version}}-jre-alpine
+          build-args: BASE_IMAGE=europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-${{matrix.version}}-dev
           pull: true
           push: ${{ github.ref_name == 'master' }}
           tags: ghcr.io/${{ github.repository }}/java:${{matrix.version}}
@@ -60,7 +67,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        version: [ '21', '24']
+        version: [ '21', '25']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
@@ -108,7 +115,7 @@ jobs:
     name: Trivy
     uses: navikt/fp-gha-workflows/.github/workflows/trivy.yml@main
     with:
-      build-version: 'java:21'
+      build-version: 'java:25'
     secrets: inherit
 
   trivy-distroless:
@@ -120,5 +127,5 @@ jobs:
     name: Trivy
     uses: navikt/fp-gha-workflows/.github/workflows/trivy.yml@main
     with:
-      build-version: 'distroless:21'
+      build-version: 'distroless:25'
     secrets: inherit

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,5 +18,5 @@ jobs:
     name: Trivy
     uses: navikt/fp-gha-workflows/.github/workflows/trivy.yml@main
     with:
-      build-version: 'java:24'
+      build-version: 'java:25'
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
-# Foreldrepenger baseimage
-Base docker images for Foreldrepenger.
+# Foreldrepenger Baseimages
+Prosjektet bygger JRE docker images brukt av Team Foreldrepenger.
+
+Vi bygger på litt ekstra funksjonalitet på toppen av Chainguard sine images for å gjøre det enklere å kjøre Java applikasjoner lokalt 
+og på Nav sin Nais platform, og for å gjøre det likt for alle applikasjoner.
 
 Tilgjengelige images:
-* Adoptium Temurin 21, 24 https://adoptium.net/ ([`java`](java))
-* Distroless 21 ([`distroless`](distroless))
+* Chainguard OpenJdk 21, 25 Dev https://images.chainguard.dev/directory/image/jre/versions ([`java`](java))
+* Chainguard OpenJdk 21, 25 https://images.chainguard.dev/directory/image/jre/versions ([`distroless`](distroless))
 
 ## Bygg lokalt
 ```shell script
-docker build -t java24 --build-arg base_image=eclipse-temurin:24-jre ./java
+docker build -t java25 --build-arg base_image=europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25-dev ./java
 ```
 ## Hvordan ta i bruk base image
 
 ### Java
 ```dockerfile
-FROM ghcr.io/navikt/fp-baseimages/java:<21|24>-nonroot
+FROM ghcr.io/navikt/fp-baseimages/java:<21|25>
 COPY <path-to-jar> app.jar
 ```
 

--- a/distroless/Dockerfile
+++ b/distroless/Dockerfile
@@ -7,7 +7,7 @@ COPY --from=busybox:stable-musl /bin/wget /usr/bin/wget
 # Working dir for RUN, CMD, ENTRYPOINT, COPY and ADD (required because of nonroot user cannot run commands in root)
 WORKDIR /app
 
-ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"
+ENV TZ="Europe/Oslo"
 
 ENV JDK_JAVA_OPTIONS="-XX:+PrintCommandLineFlags \
                       -XX:ActiveProcessorCount=2 \

--- a/distroless/README.md
+++ b/distroless/README.md
@@ -1,11 +1,11 @@
-Foreldrepenger Distroless baseimage
+Foreldrepenger Chainguard Java Distroless baseimage
 =====================
 
 Basic Usage
 ---------------------
 
 ```Dockerfile
-FROM ghcr.io/navikt/fp-baseimages/distroless:21
+FROM ghcr.io/navikt/fp-baseimages/distroless:25
 
 LABEL org.opencontainers.image.source=https://github.com/navikt/ft-inntektsmelding
 
@@ -24,7 +24,6 @@ ENV JDK_JAVA_OPTIONS="${JDK_JAVA_OPTIONS} -Dlogback.configurationFile=conf/logba
 
 Or by specifying the `JAVA_TOOL_OPTIONS` environment variable in the Dockerfile.
 
-
 ### Standard setup
 
 The working director is sett to `/app`.
@@ -34,7 +33,7 @@ WORKDIR /app
 
 The image sets a set of standard environment variables:
 ```Dockerfile
-ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"
+ENV TZ="Europe/Oslo"
 
 ENV JDK_JAVA_OPTIONS="-XX:+PrintCommandLineFlags \
                       -XX:ActiveProcessorCount=2 \

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,22 +1,10 @@
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE:-"eclipse-temurin:24-jre-alpine"}
+FROM ${BASE_IMAGE:-"europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25-dev"}
 
-RUN umask o+r \
-    && addgroup --system --gid 1069 apprunner \
-    && adduser --system --uid 1069 -G apprunner apprunner \
-    && mkdir -p /app \
-    && chown -R apprunner:apprunner /app \
-    && apk update \
-    && apk upgrade \
-    && apk add --no-cache musl-locales \
-    && sed -i '/nb_NO.UTF-8/s/^# //' /etc/apk/world \
-    && echo "export LANG=nb_NO.UTF-8" >> /etc/profile \
-    && echo "export LC_ALL=nb_NO.UTF-8" >> /etc/profile
+ENV TZ="Europe/Oslo"
 
-ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb_NO.UTF-8' TZ="Europe/Oslo"
-
-COPY --chown=apprunner:root entrypoint.sh /entrypoint.sh
-COPY --chown=apprunner:root init-scripts/ /init-scripts
+COPY entrypoint.sh /entrypoint.sh
+COPY init-scripts/ /init-scripts
 
 ENV DEFAULT_JVM_OPTS="-XX:+PrintCommandLineFlags \
                       -XX:ActiveProcessorCount=2 \
@@ -26,6 +14,5 @@ ENV DEFAULT_JVM_OPTS="-XX:+PrintCommandLineFlags \
                       -Dlogback.configurationFile=conf/logback.xml"
 
 WORKDIR /app
-USER apprunner
 EXPOSE 8080
 ENTRYPOINT ["/entrypoint.sh"]

--- a/java/README.md
+++ b/java/README.md
@@ -1,4 +1,4 @@
-Foreldrepenger Java baseimage
+Foreldrepenger Chainguard Java baseimage
 =====================
 
 Basic Usage


### PR DESCRIPTION
- Bumper java 24 til java 25
- bruker Chainguard images 
- bruker -dev tag der vi trenger å gjøre noe mer i baseimage til å kjøre applikasjonen.
- oppdatert readme.