### PR TITLE
Justere ActProcCount og MaxRamPct for G1GC

### DIFF
--- a/chainguard/jre/Dockerfile
+++ b/chainguard/jre/Dockerfile
@@ -10,8 +10,9 @@ WORKDIR /app
 ENV TZ="Europe/Oslo"
 
 ENV JDK_JAVA_OPTIONS="-XX:+PrintCommandLineFlags \
+-XX:ActiveProcessorCount=2 \
 -XX:+UseG1GC \
--XX:MaxRAMPercentage=75 \
+-XX:MaxRAMPercentage=70 \
 -Duser.timezone=Europe/Oslo \
 -Duser.language=nb \
 -Duser.country=NO \


### PR DESCRIPTION
Etter en del dialog med flere AI-asistenter, så ser vi at valg av G1GC med lav cpu-request har noen sideeffekter.
G1GC allokerer minne ut fra limit, ikke request. Derfor bør request = 0,8 * limit - eller limit = 1,25 * request.
ActiveProcessorCount er vanlig ergonomics-trick og mer nødvendig for G1GC.
Request er garantert cpu og minne. Limit er ikke garantert. Request bør være over normalbruk.
