### PR TITLE
Chore: Fjerne J21, Legg til J26 og latest. Ratchet-justering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,13 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v6 # ratchet:exclude
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4 # ratchet:exclude
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4 # ratchet:exclude
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4.0.0
 
       # Publisering på ghcr
       - name: Login to GitHub Packages Docker Registry
@@ -56,7 +56,7 @@ jobs:
           team: teamforeldrepenger
 
       - name: Build and push
-        uses: docker/build-push-action@v7 # ratchet:exclude
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # ratchet:docker/build-push-action@v7.1.0
         with:
           context: chainguard/jre
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,21 +22,27 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        version: [ '21', '25']
+        include:
+          - upstream_tag: 'openjdk-25'
+            fp_tag: 'jre-25'
+          - upstream_tag: 'openjdk-26'
+            fp_tag: 'jre-26'
+          - upstream_tag: 'latest'
+            fp_tag: 'jre-latest'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6 # ratchet:exclude
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@v4 # ratchet:exclude
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v4 # ratchet:exclude
 
       # Publisering på ghcr
       - name: Login to GitHub Packages Docker Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -50,13 +56,13 @@ jobs:
           team: teamforeldrepenger
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@v7 # ratchet:exclude
         with:
           context: chainguard/jre
           platforms: linux/amd64,linux/arm64
-          build-args: BASE_IMAGE=europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-${{matrix.version}}
+          build-args: BASE_IMAGE=europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:${{matrix.upstream_tag}}
           pull: true
           push: ${{ github.ref_name == 'master' }}
-          tags: ghcr.io/${{ github.repository }}/chainguard:jre-${{matrix.version}}
+          tags: ghcr.io/${{ github.repository }}/chainguard:${{matrix.fp_tag}}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/package_cleanup.yml
+++ b/.github/workflows/package_cleanup.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete old java containers
-        uses: actions/delete-package-versions@v5
+        uses: actions/delete-package-versions@v5 # ratchet:exclude
         with:
           package-name: fp-baseimages/java
           package-type: container
@@ -20,7 +20,7 @@ jobs:
           delete-only-untagged-versions: true
 
       - name: Delete old chainguard JRE containers
-        uses: actions/delete-package-versions@v5
+        uses: actions/delete-package-versions@v5 # ratchet:exclude
         with:
           package-name: fp-baseimages/chainguard
           package-type: container
@@ -28,7 +28,7 @@ jobs:
           delete-only-untagged-versions: true
 
       - name: Delete old distroless containers
-        uses: actions/delete-package-versions@v5
+        uses: actions/delete-package-versions@v5 # ratchet:exclude
         with:
           package-name: fp-baseimages/distroless
           package-type: container

--- a/.github/workflows/package_cleanup.yml
+++ b/.github/workflows/package_cleanup.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete old java containers
-        uses: actions/delete-package-versions@v5 # ratchet:exclude
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # ratchet:actions/delete-package-versions@v5.0.0
         with:
           package-name: fp-baseimages/java
           package-type: container
@@ -20,7 +20,7 @@ jobs:
           delete-only-untagged-versions: true
 
       - name: Delete old chainguard JRE containers
-        uses: actions/delete-package-versions@v5 # ratchet:exclude
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # ratchet:actions/delete-package-versions@v5.0.0
         with:
           package-name: fp-baseimages/chainguard
           package-type: container
@@ -28,7 +28,7 @@ jobs:
           delete-only-untagged-versions: true
 
       - name: Delete old distroless containers
-        uses: actions/delete-package-versions@v5 # ratchet:exclude
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # ratchet:actions/delete-package-versions@v5.0.0
         with:
           package-name: fp-baseimages/distroless
           package-type: container

--- a/chainguard/jre/README.md
+++ b/chainguard/jre/README.md
@@ -24,6 +24,9 @@ ENV JDK_JAVA_OPTIONS="${JDK_JAVA_OPTIONS} -Dlogback.configurationFile=conf/logba
 
 Or by specifying the `JAVA_TOOL_OPTIONS` environment variable in the Dockerfile.
 
+The JVM and GC ergonomics are based on memory limits, not request. Set the request above steady-state reported usage, and limit 25% above the request.
+If the application memory limit is well above 1Gi, study the non-heap space usage and consider increasing MaxRAMPercentage to 80-90 or above if there is an over-allocation to non-heap space.
+
 
 ### Standard setup
 
@@ -32,13 +35,14 @@ The working director is sett to `/app`.
 WORKDIR /app
 ```
 
-The image sets a set of standard environment variables:
+The image sets a set of standard environment variables, selecting G1GC and corresponding GC ergonomics:
 ```Dockerfile
 ENV TZ="Europe/Oslo"
 
 ENV JDK_JAVA_OPTIONS="-XX:+PrintCommandLineFlags \
+-XX:ActiveProcessorCount=2 \
 -XX:+UseG1GC \
--XX:MaxRAMPercentage=75 \
+-XX:MaxRAMPercentage=70 \
 -Duser.timezone=Europe/Oslo \
 -Duser.language=nb \
 -Duser.country=NO \


### PR DESCRIPTION
Fjerner bygging av 21-baseimage. Legger til jre-26 og latest. Latest blir til Java 27 sent september 2026.
Apps kan da bruke fp-baseimages/chainguard:jre-25, ...:jre-26, ...:jre-latest
Mulig vi skal ratchet-strap alle eksterne actions til en gitt versjon framfor v2, v4, .... Se disk i fp-gha-workflows